### PR TITLE
chore: Improve release workflow/process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,41 @@ jobs:
       tests_path: tests
     secrets: inherit
 
-  publish:
+  release:
     needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update CHANGELOG
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ github.token }}
+          tag: ${{ github.ref_name }}
+          excludeTypes: "build,other,style"
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: false
+          makeLatest: true
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changes }}
+          token: ${{ github.token }}
+
+      - name: Commit CHANGELOG.md
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: main
+          commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }}'
+          file_pattern: CHANGELOG.md
+
+  publish:
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.2] - 2024-09-17
+### :wrench: Chores
+- [`2e5b35b`](https://github.com/tigattack/dvla-ves-api-py/commit/2e5b35bc73aa00ae58ea2bb2f85269b618088557) - fix project URLs *(commit by [@tigattack](https://github.com/tigattack))*
+- [`347370a`](https://github.com/tigattack/dvla-ves-api-py/commit/347370a5483b71830f0880768449b5886b0deefc) - bump version *(commit by [@tigattack](https://github.com/tigattack))*
+
+
+## [1.0.1] - 2024-09-17
+### :wrench: Chores
+- [`660a254`](https://github.com/tigattack/dvla-ves-api-py/commit/660a254888016c3f4112da8119e61d9edfbaa002) - fix project URLs *(commit by [@tigattack](https://github.com/tigattack))*
+- [`3e87535`](https://github.com/tigattack/dvla-ves-api-py/commit/3e875351ecf146ebed73adeacb62a11cba97e7b8) - bump version to 1.0.1 *(commit by [@tigattack](https://github.com/tigattack))*
+
+
+## [1.0.0] - 2024-09-17
+### :sparkles: New Features
+- [`8fda4bc`](https://github.com/tigattack/dvla-ves-api-py/commit/8fda4bca1224c17a24d0200036f5786bc9bee6e1) - make error handling more pythonic *(commit by [@tigattack](https://github.com/tigattack))*
+
+### :bug: Bug Fixes
+- [`7c3a599`](https://github.com/tigattack/dvla-ves-api-py/commit/7c3a5993d2b6c3e2da9a1df9e6a11c79c42d9fa3) - **deps**: update dependency pydantic to v2.9.0 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`7ed7853`](https://github.com/tigattack/dvla-ves-api-py/commit/7ed7853c1f357a46ce6fb7c7b0c362838341e0e0) - **deps**: update dependency pydantic to v2.9.1 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`b23faed`](https://github.com/tigattack/dvla-ves-api-py/commit/b23faedcbbae4d3d764e6d5e37484d09ccaccedd) - only raise list of errors when >1 errors *(commit by [@tigattack](https://github.com/tigattack))*
+
+### :recycle: Refactors
+- [`36fea01`](https://github.com/tigattack/dvla-ves-api-py/commit/36fea01a1dd6dadf5dee27da6247ae41b9b35228) - replace `typing` generics with builtins *(commit by [@tigattack](https://github.com/tigattack))*
+- [`b228489`](https://github.com/tigattack/dvla-ves-api-py/commit/b22848904b671ece435120ce1353282ca75acf71) - rename Vehicle model to VehicleResponse *(commit by [@tigattack](https://github.com/tigattack))*
+- [`b3b3e9a`](https://github.com/tigattack/dvla-ves-api-py/commit/b3b3e9a317f0434cdc318fefd39f6df97f045eeb) - use `map` to parse dates in parse_month validator *(commit by [@tigattack](https://github.com/tigattack))*
+- [`f930206`](https://github.com/tigattack/dvla-ves-api-py/commit/f93020680158793d1c46e2927a2158d5522ba573) - tweak exception management *(commit by [@tigattack](https://github.com/tigattack))*
+
+### :white_check_mark: Tests
+- [`f099241`](https://github.com/tigattack/dvla-ves-api-py/commit/f099241db20dea89b50d8d1c312e15d0541239bb) - update tests to reflect changes *(commit by [@tigattack](https://github.com/tigattack))*
+
+### :memo: Documentation Changes
+- [`bb5d91e`](https://github.com/tigattack/dvla-ves-api-py/commit/bb5d91ea8b058c5f23220b638a4d7995a4219a67) - **py**: add project URLs *(commit by [@tigattack](https://github.com/tigattack))*
+- [`44d2560`](https://github.com/tigattack/dvla-ves-api-py/commit/44d2560d48310bbe1638e251106e123243ea6c0b) - **readme**: add badges *(commit by [@tigattack](https://github.com/tigattack))*
+- [`f9defa4`](https://github.com/tigattack/dvla-ves-api-py/commit/f9defa429a00825b755fa1f43e4397b77fa0fed1) - improve docstring for `get_vehicle` *(commit by [@tigattack](https://github.com/tigattack))*
+- [`aaa7dac`](https://github.com/tigattack/dvla-ves-api-py/commit/aaa7dace766f16cba1617f093e521e9b79547d1c) - update readme to reflect changes *(commit by [@tigattack](https://github.com/tigattack))*
+
+### :wrench: Chores
+- [`62f8bc3`](https://github.com/tigattack/dvla-ves-api-py/commit/62f8bc3cb92ab5c8474f71311b52241c888b97b5) - **renovate**: enable automerge for dev deps *(commit by [@tigattack](https://github.com/tigattack))*
+- [`116e63a`](https://github.com/tigattack/dvla-ves-api-py/commit/116e63acd128c261a37fc9ad72c17fa0b5cbee2b) - **renovate**: update config to json5 *(commit by [@tigattack](https://github.com/tigattack))*
+- [`c72cbd8`](https://github.com/tigattack/dvla-ves-api-py/commit/c72cbd8ef7c50f2ebce5737f48f305d8b13cc962) - **renovate**: fix poetry deptype match *(commit by [@tigattack](https://github.com/tigattack))*
+- [`ea71456`](https://github.com/tigattack/dvla-ves-api-py/commit/ea7145677ed10b3da5d664b9fb447d3c911abae0) - **deps**: update dependency mypy to v1.11.2 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`9706391`](https://github.com/tigattack/dvla-ves-api-py/commit/9706391b37cc1f35a8607fcf318bb73ab0b47892) - **deps**: update dependency ruff to v0.6.2 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`7d4cdc8`](https://github.com/tigattack/dvla-ves-api-py/commit/7d4cdc84a905b1e02ff3ca2b99fc29574e3cf877) - **deps**: update dependency pytest-asyncio to ^0.24.0 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`b866f98`](https://github.com/tigattack/dvla-ves-api-py/commit/b866f9811d626e7b1135f64893b8a383e35cbb75) - **deps**: update dependency ruff to v0.6.3 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`68e57ea`](https://github.com/tigattack/dvla-ves-api-py/commit/68e57ea497e2754a27bc76208cc25da4c2f4f8d8) - **deps**: update dependency ruff to v0.6.4 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`8606269`](https://github.com/tigattack/dvla-ves-api-py/commit/8606269f3eb608a8d8084918aef7cf2f3324fb34) - **deps**: update dependency pytest to v8.3.3 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`2b8f98a`](https://github.com/tigattack/dvla-ves-api-py/commit/2b8f98a1ffd27d7fd7e5c5f1d89d5db8aad7ee24) - **deps**: update dependency ruff to v0.6.5 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`30832ac`](https://github.com/tigattack/dvla-ves-api-py/commit/30832acbe829579cad8022dfe363ee27fa149a96) - bump minimum Python version *(commit by [@tigattack](https://github.com/tigattack))*
+- [`dcb7196`](https://github.com/tigattack/dvla-ves-api-py/commit/dcb7196450326bca2c746c1b30e98d039e2024eb) - bump version to 1.0.0 *(commit by [@tigattack](https://github.com/tigattack))*
+
+
+## [0.1.1] - 2024-09-17
+### :wrench: Chores
+- [`77dd585`](https://github.com/tigattack/dvla-ves-api-py/commit/77dd5855b77fafc47fdef574568c07d128671ea0) - **deps**: update dependency python-dateutil to ^2.9.0-post.0 *(commit by [@renovate[bot]](https://github.com/apps/renovate))*
+- [`32a053d`](https://github.com/tigattack/dvla-ves-api-py/commit/32a053da12092dab42b5f85613008a2594af6259) - downgrade aiohttp min version *(commit by [@tigattack](https://github.com/tigattack))*
+- [`b7893ac`](https://github.com/tigattack/dvla-ves-api-py/commit/b7893ac8918b11f996d44c0fea1dd93ae455d59d) - bump project version *(commit by [@tigattack](https://github.com/tigattack))*
+
+[0.1.1]: https://github.com/tigattack/dvla-ves-api-py/compare/0.1.0...0.1.1
+[1.0.0]: https://github.com/tigattack/dvla-ves-api-py/compare/0.1.1...1.0.0
+[1.0.1]: https://github.com/tigattack/dvla-ves-api-py/compare/1.0.0...1.0.1
+[1.0.2]: https://github.com/tigattack/dvla-ves-api-py/compare/1.0.1...1.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ packages = [
 [tool.poetry.urls]
 Repository = "https://github.com/tigattack/dvla-ves-api-py"
 Issues = "https://github.com/tigattack/dvla-ves-api-py/issues"
+Changelog = "https://github.com/tigattack/dvla-ves-api-py/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires-python = ">=3.9"
 
 [tool.poetry]
 name = "dvla_vehicle_enquiry_service"
-version = "1.0.2"
+version = "1.0.3"
 description = "Python SDK for DVLA Vehicle Enquiry Service API"
 authors = ["tigattack <10629864+tigattack@users.noreply.github.com>"]
 readme = "README.md"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommitTypeAll(chore)"
   ],
   packageRules: [
     // Auto update Poetry 'dev' dependency group


### PR DESCRIPTION
Publish workflow will now:
* Generate changelog
* Create release

Other changes:
* Backfill changelog
* Renovate will now use `chore` semantic commit type
* Add changelog URL to project URLs for PyPi
* Bump version to 1.0.3